### PR TITLE
Correcting week days spelling using half-space (Nim-fasele)

### DIFF
--- a/src/CalendarUtils.php
+++ b/src/CalendarUtils.php
@@ -591,7 +591,7 @@ class CalendarUtils
                 break;
             case 'sun':
             case 'sunday':
-                $ret = 'یکشنبه';
+                $ret = 'یک‌شنبه';
                 $n = 2;
                 break;
             case 'mon':
@@ -601,7 +601,7 @@ class CalendarUtils
                 break;
             case 'tue':
             case 'tuesday':
-                $ret = 'سه شنبه';
+                $ret = 'سه‌شنبه';
                 $n = 4;
                 break;
             case 'wed':
@@ -611,7 +611,7 @@ class CalendarUtils
                 break;
             case 'thu':
             case 'thursday':
-                $ret = 'پنجشنبه';
+                $ret = 'پنج‌شنبه';
                 $n = 6;
                 break;
             case 'fri':


### PR DESCRIPTION
The correct week day names are with Nim-fasele and I've corrected them.